### PR TITLE
break after the first match rather than finding all matches

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,11 @@
 var list = require('./list');
-var regex = new RegExp('(' + list.join('|') + ')', 'ig');
+var regex = new RegExp('(' + list.join('|') + ')', 'i');
 
 module.exports = function(userAgent) {
-    regex.lastIndex = 0;
     return regex.test(userAgent);
 };
 
 module.exports.extend = function(additionalFilters){
     list = list.concat(additionalFilters);
-    regex = new RegExp('(' + list.join('|') + ')', 'ig');
+    regex = new RegExp('(' + list.join('|') + ')', 'i');
 }


### PR DESCRIPTION
Performance: break the operation after first match.
It also does not keep `lastIndex`, so we get to remove that line