### PR TITLE
Add "exclude" method

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,18 @@ isBot.extend(myList);
 
 isBot("Mozilla/5.0") // true
 ```
+
+### excluding
+
+```js
+isBot('Ceramic Tile Installation Guide') // true
+
+var myList = [
+	'Ceramic Tile Installation Guide',
+	'NORAD National Defence Network'
+];
+
+isBot.exclude(myList);
+
+isBot('Ceramic Tile Installation Guide') // false
+```

--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 var list = require('./list');
-var regex = new RegExp('(' + list.join('|') + ')', 'i');
+var regex;
+function update() {
+	regex = new RegExp('(' + list.join('|') + ')', 'i');
+}
+update();
 
 module.exports = function(userAgent) {
     return regex.test(userAgent);
@@ -7,5 +11,16 @@ module.exports = function(userAgent) {
 
 module.exports.extend = function(additionalFilters){
     list = list.concat(additionalFilters);
-    regex = new RegExp('(' + list.join('|') + ')', 'i');
+    update();
+}
+
+module.exports.exclude = function(excludedFilters){
+    var i = excludedFilters.length;
+    while (i--) {
+      var index = list.lastIndexOf(excludedFilters[i]);
+      if (index > 0) {
+        list.splice(index, 1);
+      }
+    }
+    update();
 }

--- a/test.js
+++ b/test.js
@@ -42,12 +42,29 @@ describe('Exclude', function(){
     var cubot = 'Mozilla/5.0 (Linux; Android 8.0.0; CUBOT_P20) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36';
     var excludedFilters = ['bot'];
 
-    it('should be detected (' + cubot + ') as bot', function() {
+    afterEach(function() {
+        delete require.cache[require.resolve('./')];
+        delete require.cache[require.resolve('./list')];
+        isBot = require('./');
+    });
+
+    it('should detect Cubot as bot', function() {
         isBot(cubot).should.be.true;
     });
 
-    it('should not be detected (' + customBrowser + ') as bot', function() {
+    it('should not detect Cubot as bot', function() {
         isBot.exclude(excludedFilters);
+        isBot(cubot).should.be.false;
+    });
+
+    it('should detect Googlebot, but not Cubot (use case)', function() {
+        isBot('Googlebot').should.be.true;
+        isBot(cubot).should.be.true;
+
+        isBot.exclude(excludedFilters);
+        isBot.extend(['googlebot']);
+
+        isBot('Googlebot').should.be.true;
         isBot(cubot).should.be.false;
     });
 });

--- a/test.js
+++ b/test.js
@@ -37,3 +37,17 @@ describe('Extend', function(){
         isBot(customBrowser).should.be.true;
     });
 });
+
+describe('Exclude', function(){
+    var cubot = 'Mozilla/5.0 (Linux; Android 8.0.0; CUBOT_P20) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36';
+    var excludedFilters = ['bot'];
+
+    it('should be detected (' + cubot + ') as bot', function() {
+        isBot(cubot).should.be.true;
+    });
+
+    it('should not be detected (' + customBrowser + ') as bot', function() {
+        isBot.exclude(excludedFilters);
+        isBot(cubot).should.be.false;
+    });
+});


### PR DESCRIPTION
This option will allow consumers to execute remediation of rules.

### How is this addressing issue #29 ?
Supporting CUBOT seems to require a lookbehind rule, which is not yet supported by all Javascript engines.
![](https://user-images.githubusercontent.com/516342/57768094-8e7ab080-7713-11e9-8ae0-3e334111a0d1.png)

If, for instance, you are running this code on a node server where you control the version running, you may want to use the lookbehind feature to detect user agents containing "bot" but not Cubot:
```js
isBot('Googlebot') // true
isBot('cubot') // true

isBot.exclude(['bot']);
isBot.extend(['(?<! cu)bot']);

isBot('Googlebot') // true
isBot('cubot') // false
```