### PR TITLE
Reduce package download size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+*.txt
+test.js


### PR DESCRIPTION
## TL;DR
- Does **not** pack txt files (UA lists) and test file
- Package size reduced from 110 to 8 kB

## `npm pack` diff

```diff
npm notice 📦  isbot@2.2.2
npm notice === Tarball Contents ===
npm notice 640B    package.json
- npm notice 503.1kB browsers.txt
- npm notice 138.7kB crawlers.txt
npm notice 320B    index.js
npm notice 1.1kB   LICENSE
npm notice 18.0kB  list.js
npm notice 667B    README.md
- npm notice 1.2kB   test.js
npm notice === Tarball Details ===
npm notice name:          isbot
npm notice version:       2.2.2
npm notice filename:      isbot-2.2.2.tgz
- npm notice package size:  110.0 kB
+ npm notice package size:  8.3 kB
- npm notice unpacked size: 663.7 kB
+ npm notice unpacked size: 20.7 kB
- npm notice shasum:        4136f4bb634a2d5bb370e4c412172dfe81886a61
+ npm notice shasum:        cf3d739ba7ca903edf605135fdd35871c37e8f1e
- npm notice integrity:     sha512-Mst1KK/GaP9EZ[...]1R3nIa8oe4mGg==
+ npm notice integrity:     sha512-FTYlmr0DYzRES[...]gfuiue3By1o2g==
- npm notice total files:   8
+ npm notice total files:   5
```
