### PR TITLE
Fix TS definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,12 +8,14 @@ declare function testUserAgent(userAgent: string): boolean;
  * Extend the built-in list of bot user agent
  * @param additionalFilters An array of user agents
  */
-export function extend(additionalFilters: string[]): void;
+declare function extend(additionalFilters: string[]): void;
 
 /**
  * Removes a set of user agent from the built-in list
  * @param excludedFilters An array of user agents
  */
-export function exclude(excludedFilters: string[]): void;
+declare function exclude(excludedFilters: string[]): void;
 
-export default testUserAgent;
+testUserAgent.extend = extend;
+testUserAgent.exclude = exclude;
+export = testUserAgent;


### PR DESCRIPTION
Fixes #41.

Interesting that #39 fixed the first function `testUserAgent` with keyword declare, but not the other two. And the export is totally incorrect unless you wrote something like `module.exports.default = xx` in the js source file.