### PR TITLE
Add periodic tests

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,28 @@
+name: Maintenance
+
+on:
+  schedule:
+    # At 12:00 on Monday and Thursday
+    - cron:  '0 12 * * 1,4'
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ '12' ]
+    steps:
+    - uses: actions/checkout@v1
+    - run: npm i
+    - name: Create issue if tests fail
+      run: |
+        npm t || curl --request POST \
+        --url https://api.github.com/repos/${{ github.repository }}/issues \
+        --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+        --header 'content-type: application/json' \
+        --data '{
+          "title": "Automated issue for failing periodic tests",
+          "body": "This issue is automatically created.\n - workflow `${{ github.workflow }}`\n - commit #${{ github.sha }}",
+          "assignee": "omrilotan"
+          }'

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -2,8 +2,8 @@ name: Maintenance
 
 on:
   schedule:
-    # At 10:00 on Monday and Thursday
-    - cron:  '0 10 * * 1,4'
+    # At 11:00 on Monday and Thursday
+    - cron:  '0 11 * * 1,4'
 
 jobs:
   test:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -2,8 +2,8 @@ name: Maintenance
 
 on:
   schedule:
-    # At 12:00 on Monday and Thursday
-    - cron:  '0 12 * * 1,4'
+    # At 10:00 on Monday and Thursday
+    - cron:  '0 10 * * 1,4'
 
 jobs:
   test:


### PR DESCRIPTION
Addressing issue #15 

- NPM prepare (runs after install) downloads a user agent list from [monperrus/crawler-user-agents](https://github.com/monperrus/crawler-user-agents)
- Tests run
- If tests fail - an issue is created

Since user agent databases are costly - I'm going to try to work with this open source repository for now

I want to see this cron running a couple of times - after which I think I'll decrease the frequency to once every Monday.