### PR TITLE
Improve lookbehind RegExp support detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ module.exports.exclude = function (excludedFilters) {
 try {
   // Address: Cubot browser
   // Risk: Uses lookbehind assertion
-  /(?<! cu)bot/.test('dangerbot')
+  new RegExp('(?<! cu)bot').test('dangerbot')
   list.splice(list.lastIndexOf('bot'), 1)
   list.push('(?<! cu)bot')
 } catch (error) {


### PR DESCRIPTION
As per https://github.com/gorangajic/isbot/pull/50 and specifically https://github.com/gorangajic/isbot/commit/acb6dcf401f32a48ec7024398f653ea9d7664f53#diff-168726dbe96b3ce427e7fedce31bb0bcR70, [compatibility with non-chromium browsers was broken](https://caniuse.com/#feat=js-regexp-lookbehind).

These browsers would throw a `SyntaxError: invalid regexp group` because they can not parse the lookbehind RegExp syntax. By wrapping the RegExp in a `new RegExp` constructor with a string, we can catch the SyntaxError and restore compatibility with non-chromium browsers.

I wonder if there's a better RegExp to use here rather than the lookbehind, but this PR should restore compatibility with other browsers again.

Fixes #54 