### PR TITLE
Add periodic automated test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,23 @@ jobs:
           name: Add publish token
           command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - run: npm publish
+  periodic:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - checkout
+      - run: npm i
+      - run: |
+            npm t || curl --request POST \
+              --url https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues \
+              --header 'authorization: Bearer ${GITHUB_TOKEN}' \
+              --header 'content-type: application/json' \
+              --data '{
+                  "title": "Automated issue for failing periodic tests",
+                  "body": "This issue is automatically created. The tests are failing on branch ${CIRCLE_BRANCH}",
+                  "assignees": [ "omrilotan" ],
+                  "labels": [ "automated", "maintenance" ]
+                }'
 
 workflows:
   version: 2.1
@@ -94,6 +111,17 @@ workflows:
             - test_node_latest
             - test_browsers
             - lint_and_types
+          filters:
+            branches:
+              only:
+                - master
+  scheduled:
+    jobs:
+      - periodic
+    triggers:
+      - schedule:
+          # Every Monday at 09:00
+          cron: "0 9 * * 1"
           filters:
             branches:
               only:


### PR DESCRIPTION
This process was discontinued when the repo's automation moved from Github workflow to CircleCI

> # [Add periodic tests](https://github.com/gorangajic/isbot/pull/47)
> 
> Addressing issue #15 
>
> - NPM prepare (runs after install) downloads a user agent list from [monperrus/crawler-user-agents](https://github.com/monperrus/crawler-user-agents)
> - Tests run
> - If tests fail - an issue is created
>
> Since user agent databases are costly - I'm going to try to work with this open source repository for now
>
> I want to see this cron running a couple of times - after which I think I'll decrease the frequency to once every Monday.