### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,9 @@ isbot('Mozilla/5.0') // true
 Remove rules to user agent match RegExp (see existing rules in `list.json` file)
 
 ```js
-isbot('Google Page Speed Insights') // true
-isbot.exclude([
-  'Google Page Speed Insights',
-  'Chrome-Lighthouse'
-])
-isbot('Google Page Speed Insights') // false
+isbot('Chrome-Lighthouse') // true
+isbot.exclude(['Chrome-Lighthouse'])
+isbot('Chrome-Lighthouse') // false
 ```
 
 ### Verbose result


### PR DESCRIPTION
resolves #75 by @sebranly
> With the recent changes made in https://github.com/gorangajic/isbot/pull/72, especially removing `"Google Page Speed Insights"` rule, the documentation is now incorrect regarding `exclude`...