### PR TITLE
Join js.org as a subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Detect bots/crawlers/spiders using the user agent string.
 [![](https://img.shields.io/circleci/build/github/gorangajic/isbot?style=flat-square)](https://circleci.com/gh/gorangajic/isbot) [![](https://img.shields.io/npm/dt/isbot?style=flat-square)](https://www.npmjs.com/package/isbot) [![](https://img.shields.io/github/last-commit/gorangajic/isbot?style=flat-square)](https://github.com/gorangajic/isbot/graphs/commit-activity) [![](https://img.shields.io/librariesio/sourcerank/npm/isbot?style=flat-square)](https://libraries.io/npm/isbot)
 
 ## Check it out
-[Visit the online checker](https://gorangajic.github.io/isbot)
+[Visit the online checker](https://isbot.js.org)
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "prebuild": "which parcel || npm i parcel-bundler --no-save",
     "build": "parcel build src/index.html --out-dir docs --public-url .",
+    "postbuild": "echo isbot.js.org > docs/CNAME",
     "prestart": "which parcel || npm i parcel-bundler --no-save",
     "start": "parcel src/index.html --out-dir docs",
     "prepare": "./scripts/download-fixtures.sh",


### PR DESCRIPTION
Join as a subdomain of https://js.org/
- CNAME will be added to gh-pages post (each) build pointing to `isbot.js.org`